### PR TITLE
fix: NoteOn with velocty 0 may actually be a NoteOff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "lilypond-midi-input"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "clap",
  "getset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lilypond-midi-input"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/changelog/CHANGELOG.8
+++ b/changelog/CHANGELOG.8
@@ -1,0 +1,7 @@
+# Fix Note OFF event not being caught
+
+This release addresses both #8 and #9.
+
+According to the [MIDI 1.0 message list](https://midi.org/expanded-midi-1-0-messages-list), the status `128` corresponds to a Note OFF event. However, it appears that some keyboards re-use the status `144` (i.e. a Note ON) with a velocity of `0` to represent a Note OFF, which this tool has not taken into consideration until now.
+
+This resulted in incorrect note insertion due of a secondary status `144` MIDI message when releasing the key, and also made chord mode dysfunctional because it never sees that the notes were released.

--- a/src/midi/types.rs
+++ b/src/midi/types.rs
@@ -23,9 +23,17 @@ pub enum MidiMessageType {
 impl From<MidiMessage> for MidiMessageType {
     fn from(value: MidiMessage) -> Self {
         match value.status {
-            144 => MidiMessageType::NoteOn {
-                note: value.data1,
-                velocity: value.data2,
+            144 => match value.data2.cmp(&0) {
+                // Velocity may also determine NoteOn / NoteOff
+                std::cmp::Ordering::Less => MidiMessageType::Unknown,
+                std::cmp::Ordering::Equal => MidiMessageType::NoteOff {
+                    note: value.data1,
+                    velocity: value.data2,
+                },
+                std::cmp::Ordering::Greater => MidiMessageType::NoteOn {
+                    note: value.data1,
+                    velocity: value.data2,
+                },
             },
             128 => MidiMessageType::NoteOff {
                 note: value.data1,


### PR DESCRIPTION
Resolves #8, resolves #9
